### PR TITLE
Fix in-class initializers of const floats

### DIFF
--- a/include/private/meta/crossover.h
+++ b/include/private/meta/crossover.h
@@ -33,54 +33,54 @@ namespace lsp
         struct crossover_metadata
         {
             // Maximum supported number of bands
-            static const size_t         BANDS_MAX           = 8;
-            static const size_t         SLOPE_DFL           = 2;
+            static const size_t         BANDS_MAX               = 8;
+            static const size_t         SLOPE_DFL               = 2;
 
             // In/out gain
-            static const float          IN_GAIN_DFL         = GAIN_AMP_0_DB;
-            static const float          OUT_GAIN_DFL        = GAIN_AMP_0_DB;
+            static constexpr float          IN_GAIN_DFL         = GAIN_AMP_0_DB;
+            static constexpr float          OUT_GAIN_DFL        = GAIN_AMP_0_DB;
 
             // Makeup gain for each band
-            static const float          MAKEUP_MIN          = GAIN_AMP_M_60_DB;
-            static const float          MAKEUP_MAX          = GAIN_AMP_P_60_DB;
-            static const float          MAKEUP_DFL          = GAIN_AMP_0_DB;
-            static const float          MAKEUP_STEP         = 0.05f;
+            static constexpr float          MAKEUP_MIN          = GAIN_AMP_M_60_DB;
+            static constexpr float          MAKEUP_MAX          = GAIN_AMP_P_60_DB;
+            static constexpr float          MAKEUP_DFL          = GAIN_AMP_0_DB;
+            static constexpr float          MAKEUP_STEP         = 0.05f;
 
             // Delay for each band
-            static const float          DELAY_MIN           = 0.0f;
-            static const float          DELAY_MAX           = 1000.0f;
-            static const float          DELAY_DFL           = 0.0f;
-            static const float          DELAY_STEP          = 0.5f;
+            static constexpr float          DELAY_MIN           = 0.0f;
+            static constexpr float          DELAY_MAX           = 1000.0f;
+            static constexpr float          DELAY_DFL           = 0.0f;
+            static constexpr float          DELAY_STEP          = 0.5f;
 
             // Split frequency
-            static const float          SPLIT_FREQ_MIN      = 10.0f;
-            static const float          SPLIT_FREQ_MAX      = 20000.0f;
-            static const float          SPLIT_FREQ_DFL      = 1000.0f;
-            static const float          SPLIT_FREQ_STEP     = 0.002f;
+            static constexpr float          SPLIT_FREQ_MIN      = 10.0f;
+            static constexpr float          SPLIT_FREQ_MAX      = 20000.0f;
+            static constexpr float          SPLIT_FREQ_DFL      = 1000.0f;
+            static constexpr float          SPLIT_FREQ_STEP     = 0.002f;
 
             // Frequency analysis
-            static const float          REACT_TIME_MIN      = 0.000;
-            static const float          REACT_TIME_MAX      = 1.000;
-            static const float          REACT_TIME_DFL      = 0.200;
-            static const float          REACT_TIME_STEP     = 0.001;
-            static const size_t         FFT_RANK            = 13;
-            static const size_t         FFT_ITEMS           = 1 << FFT_RANK;
-            static const size_t         MESH_POINTS         = 640;
-            static const size_t         FILTER_MESH_POINTS  = MESH_POINTS + 2;
-            static const size_t         FFT_WINDOW          = dspu::windows::HANN;
-            static const size_t         REFRESH_RATE        = 20;
+            static constexpr float          REACT_TIME_MIN      = 0.000;
+            static constexpr float          REACT_TIME_MAX      = 1.000;
+            static constexpr float          REACT_TIME_DFL      = 0.200;
+            static constexpr float          REACT_TIME_STEP     = 0.001;
+            static const size_t         FFT_RANK                = 13;
+            static const size_t         FFT_ITEMS               = 1 << FFT_RANK;
+            static const size_t         MESH_POINTS             = 640;
+            static const size_t         FILTER_MESH_POINTS      = MESH_POINTS + 2;
+            static const size_t         FFT_WINDOW              = dspu::windows::HANN;
+            static const size_t         REFRESH_RATE            = 20;
 
             // Output frequency
-            static const float          OUT_FREQ_MIN        = 0.0f;
-            static const float          OUT_FREQ_MAX        = MAX_SAMPLE_RATE;
-            static const float          OUT_FREQ_DFL        = 1000.0f;
-            static const float          OUT_FREQ_STEP       = 0.002f;
+            static constexpr float          OUT_FREQ_MIN        = 0.0f;
+            static constexpr float          OUT_FREQ_MAX        = MAX_SAMPLE_RATE;
+            static constexpr float          OUT_FREQ_DFL        = 1000.0f;
+            static constexpr float          OUT_FREQ_STEP       = 0.002f;
 
             // Zoom
-            static const float          ZOOM_MIN            = GAIN_AMP_M_18_DB;
-            static const float          ZOOM_MAX            = GAIN_AMP_0_DB;
-            static const float          ZOOM_DFL            = GAIN_AMP_0_DB;
-            static const float          ZOOM_STEP           = 0.0125f;
+            static constexpr float          ZOOM_MIN            = GAIN_AMP_M_18_DB;
+            static constexpr float          ZOOM_MAX            = GAIN_AMP_0_DB;
+            static constexpr float          ZOOM_DFL            = GAIN_AMP_0_DB;
+            static constexpr float          ZOOM_STEP           = 0.0125f;
         };
 
         extern const meta::plugin_t crossover_mono;


### PR DESCRIPTION
include/private/meta/crossover.h:
Change all in-class initializers of static float members to use
constexpr, which is compatible with C++11.

Relates to https://github.com/sadko4u/lsp-plugins/issues/257